### PR TITLE
Document nullability of charge_card_id

### DIFF
--- a/api/v1/tariffs/index.md
+++ b/api/v1/tariffs/index.md
@@ -29,16 +29,16 @@ The following table lists the `attributes` of these objects:
 
 | **Name**                  | **Type**      | **Example**         | **Description**                                                                                         |
 | ------------------------- | ------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
-| provider                  | String        | "Maingau Energie"   | Name of the charge card provider                                                                        |
-| name                      | String        | "EinfachStromLaden" | Name of the tariff                                                                                      |
-| direct_payment            | Boolean       | true                | This tariff can be used without registration                                                            |
-| provider_customer_tariff  | Boolean       | true                | If true, tariff is only available for customers of a provider (e.g. electricity provider for the home). |
-| branding                  | Hash or null  | -                   | If branding for the tariff is not available, then `null`                                                |
-| branding.background_color | String        | "#ff0000"           | Brand color to be used as background color to show the tariff.                                          |
-| branding.text_color       | String        | "#000000"           | Color to be used as text color to show the tariff.                                                      | branding.logo_url | String | "https://logo.com/test.png" | Brand logo to be displayed next to the tariff. |
-| supported_countries       | Array<String> | ["AT","DE"]         | List of countries where the tariff is mainly supported. If empty, it's supported in every country.      |
-| charge_card_id            | String        | "201"               | GoingElectric charge card ID                                                                            |
-| emp                       | Relationship  | -                   | Owner EMP of the tariff.                                                                                |
+| provider                  | String         | "Maingau Energie"   | Name of the charge card provider                                                                        |
+| name                      | String         | "EinfachStromLaden" | Name of the tariff                                                                                      |
+| direct_payment            | Boolean        | true                | This tariff can be used without registration                                                            |
+| provider_customer_tariff  | Boolean        | true                | If true, tariff is only available for customers of a provider (e.g. electricity provider for the home). |
+| branding                  | Hash or null   | -                   | If branding for the tariff is not available, then `null`                                                |
+| branding.background_color | String         | "#ff0000"           | Brand color to be used as background color to show the tariff.                                          |
+| branding.text_color       | String         | "#000000"           | Color to be used as text color to show the tariff.                                                      | branding.logo_url | String | "https://logo.com/test.png" | Brand logo to be displayed next to the tariff. |
+| supported_countries       | Array<String>  | ["AT","DE"]         | List of countries where the tariff is mainly supported. If empty, it's supported in every country.      |
+| charge_card_id            | String or null | "201"               | GoingElectric charge card ID                                                                            |
+| emp                       | Relationship   | -                   | Owner EMP of the tariff.                                                                                |
 
 ## Example
 


### PR DESCRIPTION
It seems that `charge_card_id` is `null` for tariffs that are not linked to any charging card from the GoingElectric database.